### PR TITLE
Apply securityContext only if it is explicitly enabled

### DIFF
--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -26,9 +26,11 @@ spec:
     spec:
       serviceAccountName: {{ include "confluence.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.synchrony.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.synchrony.securityContextEnabled }}
       {{- with .Values.synchrony.securityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       hostAliases:
         {{- include "confluence.additionalHosts" . | nindent 8 }}


### PR DESCRIPTION
## Pull request description

`confluence.synchrony.securityContextEnabled` value is not taken into account when rendering `StatefulSet` for `synchrony`.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
